### PR TITLE
Modified the install script to specifically pull down 2.1.1

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -28,8 +28,8 @@ sudo chown apache.apache ${install_dir}/cache/simplepie
 
 sudo cp -a ${script_dir}/components/wurfl-config.xml ${install_dir}/wurfl/wurfl-config.xml
 sudo cp -a ${script_dir}/components/wurfl-web_browsers_patch.xml ${install_dir}/wurfl/wurfl-web_browsers_patch.xml
-sudo wget -P ${install_dir}/temp/ http://sourceforge.net/projects/wurfl/files/WURFL/latest/wurfl-latest.xml.gz/download
-sudo gunzip -c ${install_dir}/temp/wurfl-latest.xml.gz | sudo tee ${install_dir}/temp/wurfl-latest.xml > /dev/null
-sudo mv ${install_dir}/temp/wurfl-latest.xml ${install_dir}/wurfl/wurfl.xml
+sudo wget -P ${install_dir}/temp/ http://sourceforge.net/projects/wurfl/files/WURFL/2.1.1/wurfl-2.1.1.xml.gz/download
+sudo gunzip -c ${install_dir}/temp/wurfl-2.1.1.xml.gz | sudo tee ${install_dir}/temp/wurfl-2.1.1.xml > /dev/null
+sudo mv ${install_dir}/temp/wurfl-2.1.1.xml ${install_dir}/wurfl/wurfl.xml
 
 sudo rm -rf ${install_dir}/temp


### PR DESCRIPTION
Because of the license change, the latest metadata has been moved so that you cannot just grab latest. Additionally, it looks like the license prohibits use of 2.2 with any version before 1.3 of the API.
