### PR TITLE
overqualified h1

### DIFF
--- a/root/assets/css/default/basic.src.css
+++ b/root/assets/css/default/basic.src.css
@@ -548,13 +548,13 @@ form.form-full > input[type=reset]:hover {
 /********************************************************
  * FRONT PAGE
  *******************************************************/
-body.front-page h1#header {
+body.front-page #header {
     background: #536895 url(img/header-front-page-bg.png) repeat-x;
     height: 50px;
 }
-body.front-page h1#header img {
+body.front-page #header img {
     float: none;
 }
-body.front-page h1#header span {
+body.front-page #header span {
     display: none;
 }


### PR DESCRIPTION
Removed h1 type selector prepended to the #header ID selector. This syntax is allowed by W3C standards (http://www.w3.org/TR/CSS2/selector.html), but it's considered by some to be inefficient practice: "If a rule has an ID selector as its key selector, don’t add the tag name to the rule. Since IDs are unique, adding a tag name would slow down the matching process needlessly." See https://developer.mozilla.org/en/Writing_Efficient_CSS. CSSLint (not something the MWF is following, and I'm not advocating it should) calls this sort of selector overqualified. Google also suggests removing overqualified selectors: http://code.google.com/speed/page-speed/docs/rendering.html
